### PR TITLE
Added a fetch on hidden items to fix Trakt.tv API issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ There only one sensor available under the `sensors` > `next_to_watch` array:
 
 - `show` for [TV Shows progress](https://trakt.tv/users/<username>/progress) (actually, episodes). Creates `sensor.trakt_next_to_watch_shows`
 
-There are two parameters for each sensor:
+There are three parameters for each sensor:
 
 - `max_medias` should be a positive number for how many items to grab
 - `only_aired` should be a boolean (True / False) to display only already aired episodes
 - `exclude` should be a list of shows you'd like to exclude, since it's based on your watched history. To find keys to put there, go on trakt.tv, search for a show, click on it, notice the url slug, copy/paste it. So, if I want to hide "Friends", I'll do the steps mentioned above, then land on https://trakt.tv/shows/friends, I'll just have to copy/paste the last part, `friends`, that's it
+You can also use the Trakt.tv "hidden" function to hide a show from [your calendar](https://trakt.tv/calendars/my/shows) or the [progress page](https://trakt.tv/users/<username>/progress)
 
 #### Example
 

--- a/custom_components/trakt_tv/apis/trakt.py
+++ b/custom_components/trakt_tv/apis/trakt.py
@@ -71,6 +71,7 @@ class TraktApi:
         )
 
     async def fetch_watched(self, excluded_shows: list):
+        """First, let's retrieve hidden items from user as a workaround for a potential bug in show progress_watch API"""
         hidden_shows = []
         for section in [
             "calendar",
@@ -92,6 +93,7 @@ class TraktApi:
                         section,
                     )
 
+        """Then, let's retrieve progress for current user by removing hidden or excluded shows"""
         response = await self.request("get", f"sync/watched/shows?extended=noseasons")
         raw_shows = await response.json()
         raw_medias = []


### PR DESCRIPTION
 Trakt.tv API documentation states:
```By default, any hidden seasons will be removed from the response and stats. To include these and adjust the completion stats, set the hidden flag to true.```
Like you can see here: https://github.com/dylandoamaral/trakt-integration/blob/main/custom_components/trakt_tv/apis/trakt.py#L108 we're not specifying any value for that field, that means hidden seasons shouldn't be retrieved. But sadly it's the case. I'm fixing that by fetching user's hidden items first