### PR TITLE
Fixed only_upcoming sensor and optimized function gathering to avoid 429 error

### DIFF
--- a/custom_components/trakt_tv/apis/trakt.py
+++ b/custom_components/trakt_tv/apis/trakt.py
@@ -129,7 +129,9 @@ class TraktApi:
         except KeyError:
             return False
 
-    async def fetch_watched(self, excluded_shows: list):
+    async def fetch_watched(
+        self, excluded_shows: list, excluded_finished: bool = False
+    ):
         """First, let's retrieve hidden items from user as a workaround for a potential bug in show progress_watch API"""
         cache_key = f"user_hidden_shows"
 
@@ -176,7 +178,8 @@ class TraktApi:
                 raw_show_progress = await self.fetch_show_progress(ids["trakt"])
                 is_finished = self.is_show_finished(raw_show_progress)
 
-                if is_finished:
+                """aired date and completed date will always be the same for next to watch tvshows if you're up-to-date"""
+                if excluded_finished and is_finished:
                     continue
 
                 raw_next_episode = await self.fetch_show_informations(
@@ -262,7 +265,7 @@ class TraktApi:
 
         if next_to_watch:
             excluded_shows = configuration.get_exclude_shows(identifier)
-            raw_medias = await self.fetch_watched(excluded_shows)
+            raw_medias = await self.fetch_watched(excluded_shows, not only_upcoming)
         else:
             days_to_fetch = configuration.get_upcoming_days_to_fetch(
                 identifier, all_medias

--- a/custom_components/trakt_tv/configuration.py
+++ b/custom_components/trakt_tv/configuration.py
@@ -76,3 +76,10 @@ class Configuration:
 
     def get_recommendation_max_medias(self, identifier: str) -> int:
         return self.get_max_medias(identifier, "recommendation")
+
+    def source_exists(self, source: str) -> bool:
+        try:
+            self.conf["sensors"][source]
+            return True
+        except KeyError:
+            return False


### PR DESCRIPTION
Hello @dylandoamaral !

I took some time during holidays to investigate why this integration was taking a lot of time to start during HomeAssistant boot, and I figured out the recommendation and the upcomings calls where made even if it wasn't in my configuration.

I refactored a bit the gathering code to build it dynamicaly, and now, only the necessary calls are made and I'm going from 25 calls to fetch_upcoming and 2 to fetch_recommendation to only 6 calls to fetch_upcoming 

Also, for the only_upcoming next_to_watch sensor, we can't exclude the finished show base on aired vs. completed dates, they can be the same even if a new episode is planned for the next day

Thanks man!