### PR TITLE
Feature: Implement Trakt lists as sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ trakt_tv:
           - friends
       only_upcoming:
         max_medias: 5
+    lists:
+      - friendly_name: "Christmas Watchlist"
+        private_list: True # Set to True if the list is your own private list
+        list_id: "christmas-watchlist" # Can be the slug, because it's a private list
+        max_medias: 5
+      - friendly_name: "2024 Academy Awards"
+        list_id: 26885014
+        max_medias: 5
+      - friendly_name: "Star Trek Movies"
+        list_id: 967660
+        media_type: "movie" # Filters the list to only show movies
+        max_medias: 5
 ```
 
 #### Integration Settings
@@ -174,6 +186,18 @@ There are three parameters for each sensor:
 - `max_medias` should be a positive number for how many items to grab
 - `exclude` should be a list of shows you'd like to exclude, since it's based on your watched history. To find keys to put there, go on trakt.tv, search for a show, click on it, notice the url slug, copy/paste it. So, if I want to hide "Friends", I'll do the steps mentioned above, then land on https://trakt.tv/shows/friends, I'll just have to copy/paste the last part, `friends`, that's it
   You can also use the Trakt.tv "hidden" function to hide a show from [your calendar](https://trakt.tv/calendars/my/shows) or the [progress page](https://trakt.tv/users/<username>/progress)
+
+##### Lists sensor
+
+Lists sensor allows you to fetch both public and private lists from Trakt, each list will be a sensor. The items in the list will be sorted by their rank on Trakt.
+
+There are four parameters for each sensor:
+
+  - `friendly_name` (MANDATORY) should be a string for the name of the sensor. This has to be unique for each list.
+  - `list_id` (MANDATORY) should be the Trakt list ID. For public lists the ID has to be numeric, for private lists the ID can be either the numeric ID or the slug from the URL. To get the numeric ID of a public list, copy the link address of the list before opening it. This will give you a URL like `https://trakt.tv/lists/2142753`. The `2142753` part is the numeric ID you need to use.   
+  - `private_list` (OPTIONAL) has to be set to `true` if using your own private list. Default is `false`
+  - `media_type` (OPTIONAL) can be used to filter the media type within the list, possible values are `show`, `movie`, `episode`. Default is blank, which will show all media types
+  - `max_medias` (OPTIONAL) should be a positive number for how many items to grab. Default is `3`
 
 #### Example
 

--- a/custom_components/trakt_tv/apis/trakt.py
+++ b/custom_components/trakt_tv/apis/trakt.py
@@ -17,7 +17,7 @@ from ..configuration import Configuration
 from ..const import API_HOST, DOMAIN
 from ..exception import TraktException
 from ..models.kind import BASIC_KINDS, UPCOMING_KINDS, TraktKind
-from ..models.media import Medias
+from ..models.media import Medias, Show, Movie, Episode
 from ..utils import cache_insert, cache_retrieve, deserialize_json
 
 LOGGER = logging.getLogger(__name__)
@@ -390,6 +390,79 @@ class TraktApi:
 
         return res
 
+    async def fetch_list(self, path: str, list_id: str, user_path: bool, max_items: int, media_type: str):
+        """ Fetch the list, if user_path is True, the list will be fetched from the user end-point """
+        # Add the user path if needed
+        if user_path:
+            path = f"users/me/{path}"
+
+        # Replace the list_id in the path
+        path = path.replace("{list_id}", list_id)
+
+        # Add media type filter to the path
+        if media_type:
+            # Check if the media type is supported
+            if Medias.trakt_to_class(media_type):
+                path = f"{path}/{media_type}"
+            else:
+                LOGGER.warn(f"Filtering list on {media_type} is not supported")
+                return None
+
+        # Add the limit to the path
+        path = f"{path}?limit={max_items}"
+
+        return await self.request(
+            "get", path
+        )
+
+    async def fetch_lists(self, configured_kind: TraktKind):
+
+        # Get config for all lists
+        configuration = Configuration(data=self.hass.data)
+        lists = configuration.get_sensor_config(configured_kind.value.identifier)
+
+        # Fetch the lists
+        data = await gather(
+            *[
+                self.fetch_list(
+                    configured_kind.value.path,
+                    list_config['list_id'],
+                    list_config['private_list'],
+                    list_config['max_medias'],
+                    list_config['media_type']
+                )
+                for list_config in lists
+            ]
+        )
+
+        # Process the results
+        language = configuration.get_language()
+
+        res = {}
+        for list_config, raw_medias in zip(lists, data):
+            if raw_medias is not None:
+                medias = []
+                for media in raw_medias:
+                    # Get model based on media type in data
+                    media_type = media.get('type')
+                    model = Medias.trakt_to_class(media_type)
+
+                    if model:
+                        medias.append(model.from_trakt(media))
+                    else:
+                        LOGGER.warn(f"Media type {media_type} in {list_config['friendly_name']} is not supported")
+
+                if not medias:
+                    LOGGER.warn(f"No entries found for list {list_config['friendly_name']}")
+                    continue
+
+                await gather(
+                    *[media.get_more_information(language) for media in medias]
+                )
+                res[list_config['friendly_name']] = Medias(medias)
+
+        return {configured_kind: res}
+
     async def retrieve_data(self):
         async with timeout(1800):
             configuration = Configuration(data=self.hass.data)
@@ -420,6 +493,9 @@ class TraktApi:
                     configured_kind=TraktKind.NEXT_TO_WATCH_UPCOMING,
                     only_upcoming=True,
                 ),
+                "lists": lambda: self.fetch_lists(
+                    configured_kind=TraktKind.LIST,
+                ),
             }
 
             """First, let's configure which sensors we need depending on configuration"""
@@ -442,6 +518,11 @@ class TraktApi:
                 if configuration.next_to_watch_identifier_exists(sub_source):
                     sources.append(sub_source)
                     coroutine_sources_data.append(source_function.get(sub_source)())
+
+            """Finally let's add the lists sensors if needed"""
+            if configuration.source_exists("lists"):
+                sources.append("lists")
+                coroutine_sources_data.append(source_function.get("lists")())
 
             sources_data = await gather(*coroutine_sources_data)
 

--- a/custom_components/trakt_tv/configuration.py
+++ b/custom_components/trakt_tv/configuration.py
@@ -78,6 +78,12 @@ class Configuration:
     def get_recommendation_max_medias(self, identifier: str) -> int:
         return self.get_max_medias(identifier, "recommendation")
 
+    def get_sensor_config(self, identifier: str) -> list:
+        try:
+            return self.conf["sensors"][identifier]
+        except KeyError:
+            return []
+
     def source_exists(self, source: str) -> bool:
         try:
             self.conf["sensors"][source]

--- a/custom_components/trakt_tv/models/kind.py
+++ b/custom_components/trakt_tv/models/kind.py
@@ -11,6 +11,11 @@ class CalendarInformation:
     path: str
     model: Media
 
+@dataclass
+class ListInformation:
+    identifier: str
+    name: str
+    path: str
 
 class TraktKind(Enum):
     SHOW = CalendarInformation("show", "Shows", "shows", Show)
@@ -23,6 +28,7 @@ class TraktKind(Enum):
     NEXT_TO_WATCH_UPCOMING = CalendarInformation(
         "only_upcoming", "Only Upcoming", "shows", Show
     )
+    LIST = ListInformation("lists", "", "lists/{list_id}/items")
 
     @classmethod
     def from_string(cls, string):

--- a/custom_components/trakt_tv/models/kind.py
+++ b/custom_components/trakt_tv/models/kind.py
@@ -11,11 +11,13 @@ class CalendarInformation:
     path: str
     model: Media
 
+
 @dataclass
 class ListInformation:
     identifier: str
     name: str
     path: str
+
 
 class TraktKind(Enum):
     SHOW = CalendarInformation("show", "Shows", "shows", Show)

--- a/custom_components/trakt_tv/models/media.py
+++ b/custom_components/trakt_tv/models/media.py
@@ -297,10 +297,8 @@ class Medias:
         return [first_item] + medias
 
     @staticmethod
-    def trakt_to_class(trakt_type: str) -> Type[Show] | Type[Movie] | Type[Episode] | None:
-        type_to_class = {
-            'show': Show,
-            'episode': Show,
-            'movie': Movie
-        }
+    def trakt_to_class(
+        trakt_type: str,
+    ) -> Type[Show] | Type[Movie] | Type[Episode] | None:
+        type_to_class = {"show": Show, "episode": Show, "movie": Movie}
         return type_to_class.get(trakt_type, None)

--- a/custom_components/trakt_tv/models/media.py
+++ b/custom_components/trakt_tv/models/media.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod, abstractstaticmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 from custom_components.trakt_tv.apis.tmdb import get_movie_data, get_show_data
 
@@ -295,3 +295,12 @@ class Medias:
         medias = sorted(self.items, key=lambda media: media.released)
         medias = [media.to_homeassistant() for media in medias]
         return [first_item] + medias
+
+    @staticmethod
+    def trakt_to_class(trakt_type: str) -> Type[Show] | Type[Movie] | Type[Episode] | None:
+        type_to_class = {
+            'show': Show,
+            'episode': Show,
+            'movie': Movie
+        }
+        return type_to_class.get(trakt_type, None)

--- a/custom_components/trakt_tv/schema.py
+++ b/custom_components/trakt_tv/schema.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 import pytz
 from dateutil.tz import tzlocal
 from homeassistant.helpers import config_validation as cv
-from voluptuous import ALLOW_EXTRA, PREVENT_EXTRA, In, Required, Schema
+from voluptuous import ALLOW_EXTRA, PREVENT_EXTRA, In, Required, Schema, All
 
 from .const import DOMAIN, LANGUAGE_CODES
 from .models.kind import BASIC_KINDS, NEXT_TO_WATCH_KINDS, TraktKind
@@ -41,6 +41,7 @@ def sensors_schema() -> Dict[str, Any]:
         "all_upcoming": upcoming_schema(),
         "next_to_watch": next_to_watch_schema(),
         "recommendation": recommendation_schema(),
+        "lists": All([lists_schema()]),
     }
 
 
@@ -74,6 +75,17 @@ def recommendation_schema() -> Dict[str, Any]:
         }
 
     return subschemas
+
+def lists_schema() -> dict[Required, Any]:
+    schema = {
+        Required("list_id"): cv.string,
+        Required("friendly_name"): cv.string,
+        Required("max_medias", default=3): cv.positive_int,
+        Required("private_list", default=False): cv.boolean,
+        Required("media_type", default=""): cv.string,
+    }
+
+    return schema
 
 
 configuration_schema = dictionary_to_schema(domain_schema(), extra=ALLOW_EXTRA)

--- a/custom_components/trakt_tv/schema.py
+++ b/custom_components/trakt_tv/schema.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 import pytz
 from dateutil.tz import tzlocal
 from homeassistant.helpers import config_validation as cv
-from voluptuous import ALLOW_EXTRA, PREVENT_EXTRA, In, Required, Schema, All
+from voluptuous import ALLOW_EXTRA, PREVENT_EXTRA, All, In, Required, Schema
 
 from .const import DOMAIN, LANGUAGE_CODES
 from .models.kind import BASIC_KINDS, NEXT_TO_WATCH_KINDS, TraktKind
@@ -75,6 +75,7 @@ def recommendation_schema() -> Dict[str, Any]:
         }
 
     return subschemas
+
 
 def lists_schema() -> dict[Required, Any]:
     schema = {

--- a/custom_components/trakt_tv/sensor.py
+++ b/custom_components/trakt_tv/sensor.py
@@ -123,9 +123,11 @@ class TraktSensor(Entity):
     @property
     def medias(self):
         if self.coordinator.data:
-            medias = self.coordinator.data.get(self.source, {}).get(self.trakt_kind, None)
+            medias = self.coordinator.data.get(self.source, {}).get(
+                self.trakt_kind, None
+            )
             if self.trakt_kind == TraktKind.LIST:
-                return medias.get(self.config_entry['friendly_name'], None)
+                return medias.get(self.config_entry["friendly_name"], None)
             return medias
         return None
 


### PR DESCRIPTION
Created a new implementation of the highly requested Trakt lists. Tried to match your existing code as close as possible, but let me know if you want anything changed or have any suggestions for future contributions.

Currently doesn't support sorting, but proper implementation of that would require sending additional headers to Trakt, so keeping it simple for now. Can do that in an additional PR.

Closes #74, #75 

## Testing

### Private list
```
      - friendly_name: "Sonarr Watchlist"
        private_list: True
        list_id: "sonarr-watchlist"
```
![image](https://github.com/dylandoamaral/trakt-integration/assets/70920705/15b5ab66-d21c-41f6-ae42-adb2155a5c5c)

### Public list
```
      - friendly_name: "2024 Academy Awards"
        list_id: 26885014
        max_medias: 10
```

![image](https://github.com/dylandoamaral/trakt-integration/assets/70920705/e23b5eb9-7aae-4523-b7ea-744a3845e5d7)

### Filtered list
```
      - friendly_name: "Marvel Episodes"
        list_id: 1248149
        media_type: "episode"
```
![image](https://github.com/dylandoamaral/trakt-integration/assets/70920705/1e3cbabb-ee72-4a87-a645-3be94d57a2c5)

 