### PR TITLE
Feature: Implement user stats as sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Add it as a top-level key (i.e., `trakt_tv:` is not indented) in the `configurat
 trakt_tv:
   language: en # Prefered language for movie/show title
   timezone: Europe/Paris # Prefered timezone
+  stats: True # Enable stats sensors
   sensors:
     upcoming:
       show:
@@ -104,6 +105,7 @@ trakt_tv:
 
 - `language` should be an [ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (default is "en")
 - `timezone` should be a [pytz timezone](https://gist.github.com/heyalexej/8bf688fd67d7199be4a1682b3eec7568) (default is the server timezone)
+- `stats` should be True if you want to create sensors for your stats (default is False)
 
 #### Available Sensors
 
@@ -174,6 +176,35 @@ There are three parameters for each sensor:
 - `max_medias` should be a positive number for how many items to grab
 - `exclude` should be a list of shows you'd like to exclude, since it's based on your watched history. To find keys to put there, go on trakt.tv, search for a show, click on it, notice the url slug, copy/paste it. So, if I want to hide "Friends", I'll do the steps mentioned above, then land on https://trakt.tv/shows/friends, I'll just have to copy/paste the last part, `friends`, that's it
   You can also use the Trakt.tv "hidden" function to hide a show from [your calendar](https://trakt.tv/calendars/my/shows) or the [progress page](https://trakt.tv/users/<username>/progress)
+
+##### Stats sensors
+
+Creates individual sensors giving all of your stats about the movies, shows, and episodes you have watched, collected, and rated.
+To enable set `stats` to True in the integration settings.
+
+The following sensors are available:
+- Episodes Collected
+- Episodes Comments
+- Episodes Minutes
+- Episodes Plays
+- Episodes Ratings
+- Episodes Watched
+- Movies Collected
+- Movies Comments
+- Movies Minutes
+- Movies Plays
+- Movies Ratings
+- Movies Watched
+- Network Followers
+- Network Following
+- Network Friends
+- Ratings Total
+- Seasons Comments
+- Seasons Ratings
+- Shows Collected
+- Shows Comments
+- Shows Ratings
+- Shows Watched
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Add it as a top-level key (i.e., `trakt_tv:` is not indented) in the `configurat
 trakt_tv:
   language: en # Prefered language for movie/show title
   timezone: Europe/Paris # Prefered timezone
-  stats: True # Enable stats sensors
   sensors:
     upcoming:
       show:
@@ -105,7 +104,6 @@ trakt_tv:
 
 - `language` should be an [ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (default is "en")
 - `timezone` should be a [pytz timezone](https://gist.github.com/heyalexej/8bf688fd67d7199be4a1682b3eec7568) (default is the server timezone)
-- `stats` should be True if you want to create sensors for your stats (default is False)
 
 #### Available Sensors
 
@@ -180,31 +178,47 @@ There are three parameters for each sensor:
 ##### Stats sensors
 
 Creates individual sensors giving all of your stats about the movies, shows, and episodes you have watched, collected, and rated.
-To enable set `stats` to True in the integration settings.
+Add `sensors` > `stats` with a list of the sensors you want to enable. You can enable all of them instead by adding `all` to the list.
 
-The following sensors are available:
-- Episodes Collected
-- Episodes Comments
-- Episodes Minutes
-- Episodes Plays
-- Episodes Ratings
-- Episodes Watched
-- Movies Collected
-- Movies Comments
-- Movies Minutes
-- Movies Plays
-- Movies Ratings
-- Movies Watched
-- Network Followers
-- Network Following
-- Network Friends
-- Ratings Total
-- Seasons Comments
-- Seasons Ratings
-- Shows Collected
-- Shows Comments
-- Shows Ratings
-- Shows Watched
+The available stats are available:
+ - `movies_plays`
+ - `movies_watched`
+ - `movies_minutes`
+ - `movies_collected`
+ - `movies_ratings`
+ - `movies_comments`
+ - `shows_watched`
+ - `shows_collected`
+ - `shows_ratings`
+ - `shows_comments`
+ - `seasons_ratings`
+ - `seasons_comments`
+ - `episodes_plays`
+ - `episodes_watched`
+ - `episodes_minutes`
+ - `episodes_collected`
+ - `episodes_ratings`
+ - `episodes_comments`
+ - `network_friends`
+ - `network_followers`
+ - `network_following`
+ - `ratings_total`
+
+###### Stats Example
+```yaml
+trakt_tv:
+  sensors:
+    # Create sensors for all available stats
+    stats:
+      - all
+    
+    # OR
+    
+    # Create sensors for specific stats (see available stats above)
+    stats:
+      - episodes_plays
+      - movies_minutes
+```
 
 #### Example
 

--- a/custom_components/trakt_tv/apis/trakt.py
+++ b/custom_components/trakt_tv/apis/trakt.py
@@ -460,7 +460,7 @@ class TraktApi:
                     coroutine_sources_data.append(source_function.get(sub_source)())
 
             """ Load user stats """
-            if configuration.should_load_stats():
+            if configuration.source_exists("stats"):
                 sources.append("stats")
                 coroutine_sources_data.append(source_function.get("stats")())
 

--- a/custom_components/trakt_tv/apis/trakt.py
+++ b/custom_components/trakt_tv/apis/trakt.py
@@ -390,6 +390,21 @@ class TraktApi:
 
         return res
 
+    async def fetch_stats(self):
+        # Load data
+        data = await self.request("get", f"users/me/stats")
+
+        # Flatten data dictionary
+        stats = {}
+        for key, value in data.items():
+            if isinstance(value, dict):
+                for sub_key, sub_value in value.items():
+                    stats[f"{key}_{sub_key}"] = sub_value
+            else:
+                stats[key] = value
+
+        return stats
+
     async def retrieve_data(self):
         async with timeout(1800):
             configuration = Configuration(data=self.hass.data)
@@ -420,6 +435,7 @@ class TraktApi:
                     configured_kind=TraktKind.NEXT_TO_WATCH_UPCOMING,
                     only_upcoming=True,
                 ),
+                "stats": lambda: self.fetch_stats(),
             }
 
             """First, let's configure which sensors we need depending on configuration"""
@@ -442,6 +458,11 @@ class TraktApi:
                 if configuration.next_to_watch_identifier_exists(sub_source):
                     sources.append(sub_source)
                     coroutine_sources_data.append(source_function.get(sub_source)())
+
+            """ Load user stats """
+            if configuration.should_load_stats():
+                sources.append("stats")
+                coroutine_sources_data.append(source_function.get("stats")())
 
             sources_data = await gather(*coroutine_sources_data)
 

--- a/custom_components/trakt_tv/configuration.py
+++ b/custom_components/trakt_tv/configuration.py
@@ -28,12 +28,6 @@ class Configuration:
         except KeyError:
             return datetime.now(tzlocal()).tzname()
 
-    def should_load_stats(self):
-        try:
-            return self.conf["stats"]
-        except KeyError:
-            return False
-
     def identifier_exists(self, identifier: str, source: str) -> bool:
         try:
             self.conf["sensors"][source][identifier]
@@ -83,6 +77,9 @@ class Configuration:
 
     def get_recommendation_max_medias(self, identifier: str) -> int:
         return self.get_max_medias(identifier, "recommendation")
+
+    def stats_key_exists(self, key: str) -> bool:
+        return key in self.conf["sensors"]["stats"]
 
     def source_exists(self, source: str) -> bool:
         try:

--- a/custom_components/trakt_tv/configuration.py
+++ b/custom_components/trakt_tv/configuration.py
@@ -28,6 +28,12 @@ class Configuration:
         except KeyError:
             return datetime.now(tzlocal()).tzname()
 
+    def should_load_stats(self):
+        try:
+            return self.conf["stats"]
+        except KeyError:
+            return False
+
     def identifier_exists(self, identifier: str, source: str) -> bool:
         try:
             self.conf["sensors"][source][identifier]

--- a/custom_components/trakt_tv/schema.py
+++ b/custom_components/trakt_tv/schema.py
@@ -31,6 +31,7 @@ def domain_schema() -> Schema:
             Required("timezone", default=datetime.now(tzlocal()).tzname()): In(
                 pytz.all_timezones_set
             ),
+            Required("stats", default=False): bool,
         }
     }
 

--- a/custom_components/trakt_tv/schema.py
+++ b/custom_components/trakt_tv/schema.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pytz
 from dateutil.tz import tzlocal
@@ -31,7 +31,6 @@ def domain_schema() -> Schema:
             Required("timezone", default=datetime.now(tzlocal()).tzname()): In(
                 pytz.all_timezones_set
             ),
-            Required("stats", default=False): bool,
         }
     }
 
@@ -42,6 +41,7 @@ def sensors_schema() -> Dict[str, Any]:
         "all_upcoming": upcoming_schema(),
         "next_to_watch": next_to_watch_schema(),
         "recommendation": recommendation_schema(),
+        "stats": Schema(stats_schema()),
     }
 
 
@@ -75,6 +75,34 @@ def recommendation_schema() -> Dict[str, Any]:
         }
 
     return subschemas
+
+
+def stats_schema() -> list[str]:
+    return [
+        "all",
+        "movies_plays",
+        "movies_watched",
+        "movies_minutes",
+        "movies_collected",
+        "movies_ratings",
+        "movies_comments",
+        "shows_watched",
+        "shows_collected",
+        "shows_ratings",
+        "shows_comments",
+        "seasons_ratings",
+        "seasons_comments",
+        "episodes_plays",
+        "episodes_watched",
+        "episodes_minutes",
+        "episodes_collected",
+        "episodes_ratings",
+        "episodes_comments",
+        "network_friends",
+        "network_followers",
+        "network_following",
+        "ratings_total",
+    ]
 
 
 configuration_schema = dictionary_to_schema(domain_schema(), extra=ALLOW_EXTRA)

--- a/custom_components/trakt_tv/sensor.py
+++ b/custom_components/trakt_tv/sensor.py
@@ -69,6 +69,33 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             )
             sensors.append(sensor)
 
+    # Add sensors for stats
+    if configuration.should_load_stats():
+        stats = {}
+        # Check if the coordinator has data
+        if coordinator.data:
+            stats = coordinator.data.get("stats", {})
+
+        # Create a sensor for each key in the stats
+        for key, value in stats.items():
+            # Transform the key to a more readable format
+            title = key.replace("_", " ").title()
+
+            # Skip the key if it is not a valid state
+            if isinstance(value, dict):
+                continue
+
+            # Create the sensor
+            sensor = TraktStateSensor(
+                hass=hass,
+                coordinator=coordinator,
+                prefix="Trakt Stats",
+                mdi_icon="mdi:chart-line",
+                title=title,
+                state=value,
+            )
+            sensors.append(sensor)
+
     async_add_entities(sensors)
 
 
@@ -147,6 +174,43 @@ class TraktSensor(Entity):
     def has_entity_name(self) -> bool:
         """Return if the name of the entity is describing only the entity itself."""
         return True
+
+    async def async_update(self):
+        """Request coordinator to update data."""
+        await self.coordinator.async_request_refresh()
+
+
+class TraktStateSensor(Entity):
+    """Trakt sensor to show data as state"""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        hass,
+        coordinator,
+        prefix: str,
+        mdi_icon: str,
+        title: str,
+        state: str,
+    ):
+        """Initialize the sensor."""
+        self.hass = hass
+        self.coordinator = coordinator
+        self.prefix = prefix
+        self.icon = mdi_icon
+        self.title = title
+        self.state = state
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self.prefix} {self.title}"
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity"""
+        return self.title.split("_")[-1]
 
     async def async_update(self):
         """Request coordinator to update data."""

--- a/custom_components/trakt_tv/sensor.py
+++ b/custom_components/trakt_tv/sensor.py
@@ -217,7 +217,18 @@ class TraktStateSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity"""
-        units = ["ratings", "minutes", "comments", "friends", "followers", "following", "episodes", "movies", "shows", "seasons"]
+        units = [
+            "ratings",
+            "minutes",
+            "comments",
+            "friends",
+            "followers",
+            "following",
+            "episodes",
+            "movies",
+            "shows",
+            "seasons",
+        ]
         for unit in units:
             if unit in self.title.lower():
                 return unit

--- a/custom_components/trakt_tv/sensor.py
+++ b/custom_components/trakt_tv/sensor.py
@@ -70,20 +70,27 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             sensors.append(sensor)
 
     # Add sensors for stats
-    if configuration.should_load_stats():
+    if configuration.source_exists("stats"):
         stats = {}
         # Check if the coordinator has data
         if coordinator.data:
             stats = coordinator.data.get("stats", {})
 
+        # Check if all stats are allowed
+        allow_all = configuration.stats_key_exists("all")
+
         # Create a sensor for each key in the stats
         for key, value in stats.items():
-            # Transform the key to a more readable format
-            title = key.replace("_", " ").title()
-
-            # Skip the key if it is not a valid state
+            # Skip the key if it is not a valid state (e.g. rating distribution dict)
             if isinstance(value, dict):
                 continue
+
+            # Skip if not allowed in config
+            if not allow_all and not configuration.stats_key_exists(key):
+                continue
+
+            # Transform the key to a more readable format
+            title = key.replace("_", " ").title()
 
             # Create the sensor
             sensor = TraktStateSensor(

--- a/custom_components/trakt_tv/sensor.py
+++ b/custom_components/trakt_tv/sensor.py
@@ -217,7 +217,11 @@ class TraktStateSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity"""
-        return self.title.split("_")[-1]
+        units = ["ratings", "minutes", "comments", "friends", "followers", "following", "episodes", "movies", "shows", "seasons"]
+        for unit in units:
+            if unit in self.title.lower():
+                return unit
+        return None
 
     async def async_update(self):
         """Request coordinator to update data."""


### PR DESCRIPTION
Adds Trakt account stats as state sensors allowing users to monitor and graph them.
Resolves #81

## Sensor list
![image](https://github.com/dylandoamaral/trakt-integration/assets/70920705/25427097-b26a-4008-b198-a95d4498801a)

## Individual sensor
![image](https://github.com/dylandoamaral/trakt-integration/assets/70920705/8f251c2a-95aa-4c15-9d4c-ca73c2986556)
