### PR TITLE
Allow leaving media sorted the way trakt sorts the media

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ---
 
-## Recomendations 💡
+## Recommendations 💡
 
 Having the following installed in Home Assistant will help best use this integration:
 
@@ -64,8 +64,8 @@ Add it as a top-level key (i.e., `trakt_tv:` is not indented) in the `configurat
 
 ```yaml
 trakt_tv:
-  language: en # Prefered language for movie/show title
-  timezone: Europe/Paris # Prefered timezone
+  language: en # Preferred language for movie/show title
+  timezone: Europe/Paris # Preferred timezone
   sensors:
     upcoming:
       show:
@@ -174,6 +174,9 @@ There are three parameters for each sensor:
 - `max_medias` should be a positive number for how many items to grab
 - `exclude` should be a list of shows you'd like to exclude, since it's based on your watched history. To find keys to put there, go on trakt.tv, search for a show, click on it, notice the url slug, copy/paste it. So, if I want to hide "Friends", I'll do the steps mentioned above, then land on https://trakt.tv/shows/friends, I'll just have to copy/paste the last part, `friends`, that's it
   You can also use the Trakt.tv "hidden" function to hide a show from [your calendar](https://trakt.tv/calendars/my/shows) or the [progress page](https://trakt.tv/users/<username>/progress)
+- `sort_by` _OPTIONAL_ should be a string for how to sort the list. Default is `released`. Possible values are:
+  - `released`, `title`, `trakt`
+- `sort_order` _OPTIONAL_ should be a string for the sort order. Possible values are `asc`, `desc`. Default is `asc`
 
 ##### Anticipated Sensors
 
@@ -257,7 +260,7 @@ There are four parameters for each sensor:
 - `media_type` _OPTIONAL_ can be used to filter the media type within the list, possible values are `show`, `movie`, `episode`. Default is blank, which will show all media types
 - `max_medias` _OPTIONAL_ should be a positive number for how many items to grab. Default is `3`
 - `sort_by` _OPTIONAL_ should be a string for how to sort the list. Default is `rank`. Possible values are:
-  - `rank`, `added`, `title`, `released`, `runtime`, `popularity`, `random`, `percentage`, `my_rating`, `watched`, `collected`
+  - `rank`, `added`, `title`, `released`, `runtime`, `popularity`, `random`, `percentage`, `my_rating`, `watched`, `collected`, `trakt`
   - Some options are VIP only: `imdb_rating`, `tmdb_rating`, `rt_tomatometer`, `rt_audience`, `metascore`, `votes`, `imdb_votes`, and `tmdb_votes`. The results will default to `rank` if not a VIP user
 - `sort_order` _OPTIONAL_ should be a string for the sort order. Possible values are `asc`, `desc`. Default is `asc`
 

--- a/custom_components/trakt_tv/const.py
+++ b/custom_components/trakt_tv/const.py
@@ -172,6 +172,14 @@ LANGUAGE_CODES = [
     "zu",
 ]
 
-SORT_BY_OPTIONS = ["rating", "rating_trakt", "rank", "runtime", "released", "listed_at"]
+SORT_BY_OPTIONS = [
+    "rating",
+    "rating_trakt",
+    "rank",
+    "runtime",
+    "released",
+    "listed_at",
+    "trakt",
+]
 
 SORT_HOW_OPTIONS = ["asc", "desc"]

--- a/custom_components/trakt_tv/models/media.py
+++ b/custom_components/trakt_tv/models/media.py
@@ -331,11 +331,17 @@ class Medias:
         :return: The dictionary containing all necessary information for upcoming media
                  card
         """
-        medias = sorted(
-            self.items,
-            key=lambda media: getattr(media, sort_by),
-            reverse=sort_order == "desc",
-        )
+        if sort_by == "trakt":
+            if sort_order == "desc":
+                medias = reversed(self.items)
+            else:
+                medias = self.items
+        else:
+            medias = sorted(
+                self.items,
+                key=lambda media: getattr(media, sort_by),
+                reverse=sort_order == "desc",
+            )
         medias = [media.to_homeassistant() for media in medias]
         return [first_item] + medias
 

--- a/custom_components/trakt_tv/schema.py
+++ b/custom_components/trakt_tv/schema.py
@@ -65,6 +65,8 @@ def next_to_watch_schema() -> Dict[str, Any]:
         subschemas[trakt_kind.value.identifier] = {
             Required("max_medias", default=3): cv.positive_int,
             Required("exclude", default=[]): list,
+            Required("sort_by", default="released"): In(["released", "title", "trakt"]),
+            Required("sort_order", default="asc"): In(SORT_HOW_OPTIONS),
         }
 
     return subschemas

--- a/custom_components/trakt_tv/sensor.py
+++ b/custom_components/trakt_tv/sensor.py
@@ -233,6 +233,12 @@ class TraktSensor(Entity):
             return self.medias.to_homeassistant(sort_by, sort_order)[0 : max_medias + 1]
 
         max_medias = self.configuration["max_medias"]
+
+        if "sort_by" in self.configuration:
+            sort_by = self.configuration["sort_by"]
+            sort_order = self.configuration["sort_order"]
+            return self.medias.to_homeassistant(sort_by, sort_order)[0 : max_medias + 1]
+
         return self.medias.to_homeassistant()[0 : max_medias + 1]
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 homeassistant
 black==24.2.0
-freezegun==1.2.2
+freezegun==1.5.5
 isort==5.13.2
 pytest==7.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,11 @@ def yaml():
                             "sort_order": "desc",
                         }
                     },
+                    "next_to_watch": {
+                        "only_aired": {
+                            "sort_by": "trakt",
+                        }
+                    },
                 },
             }
         }


### PR DESCRIPTION
This change adds filtering to the "next to watch" feature and adds the filtering option to leave media in the order that Trakt returned it in.

While not exactly what #139 and #114, this is a really simple change that gets closer to what they want.  For "next to watch" Trakt returns the data in the expected order.