### PR TITLE
fix: released none type error (kadeschs#159)

### DIFF
--- a/custom_components/trakt_tv/apis/trakt.py
+++ b/custom_components/trakt_tv/apis/trakt.py
@@ -299,13 +299,13 @@ class TraktApi:
 
         if next_to_watch:
             if only_aired:
-                new_medias = [media for media in medias if media.released <= now]
+                new_medias = [media for media in medias if media.released and media.released <= now]
             elif only_upcoming:
-                new_medias = [media for media in medias if media.released > now]
+                new_medias = [media for media in medias if media.released and media.released > now]
             else:
                 new_medias = medias
         else:
-            new_medias = [media for media in medias if media.released >= now]
+            new_medias = [media for media in medias if media.released and media.released >= now]
 
         await gather(*[media.get_more_information(language) for media in new_medias])
 


### PR DESCRIPTION
Ignores `next_to_watch` media without set released date by trakt.

One can argue that no release date is still an upcoming title. 
In my opinion titles without a date do not fit the `next_to_watch.only_upcoming` filter. They are to far in the future to add any value.