### PR TITLE
fix: Prevented setup timeout by throttling requests and failing fast on api errors

### DIFF
--- a/custom_components/trakt_tv/__init__.py
+++ b/custom_components/trakt_tv/__init__.py
@@ -12,11 +12,12 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
     async_get_config_entry_implementation,
 )
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .apis.trakt import TraktApi
 from .config_flow import OAuth2FlowHandler
 from .const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from .exception import TraktException
 from .schema import configuration_schema
 from .utils import update_domain_data
 
@@ -54,11 +55,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     api = TraktApi(async_get_clientsession(hass), session, hass)
 
+    # Implementing Fail Fast for the Coordinator
+    async def async_update_data():
+        try:
+            return await api.retrieve_data()
+        except TraktException as err:
+            raise UpdateFailed(f"Communication error with Trakt API: {err}")
+
     coordinator = DataUpdateCoordinator(
         hass=hass,
         logger=LOGGER,
         name="trakt",
-        update_method=api.retrieve_data,
+        update_method=async_update_data,
     )
 
     await coordinator.async_config_entry_first_refresh()
@@ -81,8 +89,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
             ]
         )
     )
-
     if unload_ok:
-        hass.data.pop(DOMAIN)
+        hass.data[DOMAIN].pop(entry.entry_id, None)
 
     return unload_ok

--- a/custom_components/trakt_tv/apis/trakt.py
+++ b/custom_components/trakt_tv/apis/trakt.py
@@ -38,6 +38,7 @@ class TraktApi:
         self.host = API_HOST
         self.oauth_session = oauth_session
         self.hass = hass
+        self._semaphore = asyncio.Semaphore(4)
 
     def cache(self) -> Dict[str, Any]:
         return self.hass.data[DOMAIN].get("cache", {})
@@ -87,16 +88,24 @@ class TraktApi:
             if response.ok:
                 text = await response.text()
                 return deserialize_json(text)
+
             elif response.status == 429:
-                wait_time = (
-                    int(response.headers.get("Retry-After", 60)) + 20
-                )  # Arbitrary value to have a security
+                wait_time = int(response.headers.get("Retry-After", 60))
+
+                if wait_time > 30:
+                    raise TraktException(
+                        f"Rate limit (429) reached on {url}. "
+                        f"Requested wait time of {wait_time}s is too long for initialization."
+                    )
+
                 return await self.retry_request(
-                    wait_time, response, method, url, retry, **kwargs
+                    wait_time + 2, response, method, url, retry, **kwargs
                 )
+
             else:
-                return await self.retry_request(
-                    300, response, method, url, retry, **kwargs
+                content = await response.text()
+                raise TraktException(
+                    f"HTTP {response.status} API Error on {url}. Content: {content}"
                 )
 
     async def fetch_calendar(
@@ -211,7 +220,10 @@ class TraktApi:
 
                     show["episode"] = raw_next_episode
 
-                    if raw_next_episode.get("first_aired") is not None:
+                    if (
+                        raw_next_episode
+                        and raw_next_episode.get("first_aired") is not None
+                    ):
                         show["first_aired"] = raw_next_episode["first_aired"]
 
                     return show
@@ -228,9 +240,14 @@ class TraktApi:
                     LOGGER.warning(f"Show {identifier} can't be extracted because: {e}")
                     return None
 
-        results = await gather(*[process_show(show) for show in raw_shows or []])
-        raw_medias = [r for r in results if r is not None]
+        async def process_show_with_limit(show):
+            async with self._semaphore:
+                return await process_show(show)
 
+        results = await gather(
+            *[process_show_with_limit(show) for show in raw_shows or []]
+        )
+        raw_medias = [r for r in results if r is not None]
         return raw_medias
 
     async def fetch_show_progress(self, id: str):
@@ -261,7 +278,8 @@ class TraktApi:
             f"shows/{show_id}/seasons/{season_nbr}/episodes/{episode_nbr}?extended=full",
         )
 
-        cache_insert(self.cache(), cache_key, response)
+        if response is not None:
+            cache_insert(self.cache(), cache_key, response)
 
         return response
 


### PR DESCRIPTION
Fixes the Bootstrap stage 2 timeout error that occurs when the integration takes too long to initialize due to large Trakt libraries and API rate limits (issue #170).

**Changes:**
Throttling: Added an asyncio.Semaphore(4) in fetch_watched to control the concurrency of process_show requests. This prevents triggering massive 429 (Too Many Requests) bans from the Trakt API.

Fail Fast: Removed the blocking asyncio.sleep(300) during the setup phase on API errors. The integration now raises a TraktException immediately if the required Retry-After is too long.

Coordinator Retry: Updated async_update_data to catch TraktException and raise UpdateFailed. This allows Home Assistant's DataUpdateCoordinator to handle retries gracefully in the background without blocking the main loop.